### PR TITLE
Replace get_version with version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,4 +9,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [0.1.1] - 2021-XX-XX
 - ([`:pr:1`])(https://github.com/MolSSI/mmic/pull/1) Minor updates/fixes to blueprint components.
-- ([`:pr:2`])(https://github.com/MolSSI/mmic/pull/2) Replaced classmethod `get_verion` with classproperty `version` in all components.
+- ([`:pr:2`])(https://github.com/MolSSI/mmic/pull/2) Replaces classmethod `get_verion` with classproperty `version` in all components. Removes abc methods from blueprint components.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ## [0.1.1] - 2021-XX-XX
 - ([`:pr:1`])(https://github.com/MolSSI/mmic/pull/1) Minor updates/fixes to blueprint components.
 - ([`:pr:2`])(https://github.com/MolSSI/mmic/pull/2) Replaces classmethod `get_verion` with classproperty `version` in all components. Removes abc methods from blueprint components.
+- ([`:pr:3`])(https://github.com/MolSSI/mmic/pull/3) Changes input/output abstract classmethods to classproperties. Adds test routine for ProgramHarness.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Initial release of mmic
 
 ## [0.1.1] - 2021-XX-XX
-- ([`:pr:1`])(https://github.com/MolSSI/mmic/pull/1) Renamed `TacticComponent.strategy_comp` to `TacticComponent.strategy_comps`, added classproperty from cmsel.
+- ([`:pr:1`])(https://github.com/MolSSI/mmic/pull/1) Minor updates/fixes to blueprint components.
+- ([`:pr:2`])(https://github.com/MolSSI/mmic/pull/2) Replaced classmethod `get_verion` with classproperty `version` in all components.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Initial release of mmic
 
 ## [0.1.1] - 2021-XX-XX
-- ([`:pr:1`])(https://github.com/MolSSI/mmic/pull/1) Minor updates/fixes to blueprint components.
-- ([`:pr:2`])(https://github.com/MolSSI/mmic/pull/2) Replaces classmethod `get_verion` with classproperty `version` in all components. Removes abc methods from blueprint components.
-- ([`:pr:3`])(https://github.com/MolSSI/mmic/pull/3) Changes input/output abstract classmethods to classproperties. Adds test routine for ProgramHarness.
+- ([`:pr:2`])(https://github.com/MolSSI/mmic/pull/2) Converts `get_version` to classmethod in all blueprint components. Convert `installed_comps` and `tactic_comps` to classproperty in `StrategyComponent`.
+- ([`:pr:3`])(https://github.com/MolSSI/mmic/pull/3) Replaces classmethod `get_verion` with classproperty `version` in all components. Removes abc methods from blueprint components. Changes input/output abstract classmethods to classproperties. Adds test routine for ProgramHarness.

--- a/mmic/components/base/base_component.py
+++ b/mmic/components/base/base_component.py
@@ -1,10 +1,11 @@
 import abc
 from typing import Any, Dict, List, Optional, Tuple
 from .config import TaskConfig
-from cmselemental import models
+from cmselemental.models import ProtoModel
+from cmselemental.util.decorators import classproperty
 
 
-class ProgramHarness(models.ProtoModel, metaclass=abc.ABCMeta):
+class ProgramHarness(ProtoModel, metaclass=abc.ABCMeta):
 
     _defaults: Dict[str, Any] = {}
     name: str
@@ -35,7 +36,7 @@ class ProgramHarness(models.ProtoModel, metaclass=abc.ABCMeta):
     @classmethod
     def compute(
         cls,
-        input_data: models.ProtoModel,
+        input_data: ProtoModel,
         config: Optional[TaskConfig] = None,
         scratch: Optional[bool] = False,
         thread_safe: Optional[bool] = False,
@@ -43,7 +44,7 @@ class ProgramHarness(models.ProtoModel, metaclass=abc.ABCMeta):
         node_parallel: Optional[bool] = False,
         managed_memory: Optional[bool] = False,
         extras: Optional[Dict[str, Any]] = None,
-    ) -> models.ProtoModel:
+    ) -> ProtoModel:
 
         # Validate the input model
         if isinstance(input_data, cls.input()):
@@ -94,22 +95,32 @@ class ProgramHarness(models.ProtoModel, metaclass=abc.ABCMeta):
         bool
             Returns True if the program was found, False otherwise.
         """
+        pass
 
     ## Utility
+
+    @classproperty
     @abc.abstractmethod
-    def get_version(self) -> str:
-        """Finds program, extracts version, returns normalized version string.
+    def version(cls) -> str:
+        """Returns distutils-style version string.
+
+        Examples
+        --------
+        The string ">1.0, !=1.5.1, <2.0" implies any version after 1.0 and before 2.0
+        is compatible, except 1.5.1
+
         Returns
         -------
         str
-            Return a valid, safe python version string.
+            Return a dist-utils valid version string.
+
         """
         pass
 
     ## Computers
     def build_input(
         self,
-        input_model: models.ProtoModel,
+        input_model: ProtoModel,
         config: TaskConfig = None,
         template: Optional[str] = None,
     ) -> Dict[str, Any]:
@@ -129,8 +140,8 @@ class ProgramHarness(models.ProtoModel, metaclass=abc.ABCMeta):
         raise NotImplementedError(f"execute is not implemented for {self.__class__}.")
 
     def parse_output(
-        self, outfiles: Dict[str, str], input_model: models.ProtoModel
-    ) -> models.ProtoModel:
+        self, outfiles: Dict[str, str], input_model: ProtoModel
+    ) -> ProtoModel:
         raise NotImplementedError(
             f"parse_output is not implemented for {self.__class__}."
         )

--- a/mmic/components/base/base_component.py
+++ b/mmic/components/base/base_component.py
@@ -100,7 +100,6 @@ class ProgramHarness(ProtoModel, metaclass=abc.ABCMeta):
     ## Utility
 
     @classproperty
-    @abc.abstractmethod
     def version(cls) -> str:
         """Returns distutils-style version string.
 
@@ -115,7 +114,7 @@ class ProgramHarness(ProtoModel, metaclass=abc.ABCMeta):
             Return a dist-utils valid version string.
 
         """
-        pass
+        raise NotImplementedError
 
     ## Computers
     def build_input(

--- a/mmic/components/base/base_component.py
+++ b/mmic/components/base/base_component.py
@@ -23,13 +23,13 @@ class ProgramHarness(ProtoModel, metaclass=abc.ABCMeta):
     def __init__(self, **kwargs):
         super().__init__(**{**self._defaults, **kwargs})
 
-    @classmethod
-    @abc.abstractmethod
+    @abc.abstractproperty
+    @classproperty
     def input(cls):
         ...
 
-    @classmethod
-    @abc.abstractmethod
+    @abc.abstractproperty
+    @classproperty
     def output(cls):
         ...
 
@@ -47,10 +47,10 @@ class ProgramHarness(ProtoModel, metaclass=abc.ABCMeta):
     ) -> ProtoModel:
 
         # Validate the input model
-        if isinstance(input_data, cls.input()):
-            cls.input()(**input_data.dict())
+        if isinstance(input_data, cls.input):
+            cls.input(**input_data.dict())
         elif isinstance(input_data, dict):
-            cls.input()(**input_data)
+            cls.input(**input_data)
         else:
             raise TypeError(
                 f"{type(input_data)} is not a valid input type for the {cls.__name__} component."
@@ -70,10 +70,10 @@ class ProgramHarness(ProtoModel, metaclass=abc.ABCMeta):
         _, exec_output = program.execute(input_data)
 
         # Validate the output model
-        if isinstance(exec_output, cls.output()):
-            cls.output()(**exec_output.dict())
+        if isinstance(exec_output, cls.output):
+            cls.output(**exec_output.dict())
         elif isinstance(exec_output, dict):
-            cls.output()(**exec_output)
+            cls.output(**exec_output)
         else:
             raise TypeError(
                 f"{type(exec_output)} is not a valid output type for the {cls.__name__} component."
@@ -95,10 +95,11 @@ class ProgramHarness(ProtoModel, metaclass=abc.ABCMeta):
         bool
             Returns True if the program was found, False otherwise.
         """
-        pass
+        ...
 
     ## Utility
 
+    @abc.abstractproperty
     @classproperty
     def version(cls) -> str:
         """Returns distutils-style version string.
@@ -114,7 +115,7 @@ class ProgramHarness(ProtoModel, metaclass=abc.ABCMeta):
             Return a dist-utils valid version string.
 
         """
-        raise NotImplementedError
+        ...
 
     ## Computers
     def build_input(

--- a/mmic/components/blueprints/generic_component.py
+++ b/mmic/components/blueprints/generic_component.py
@@ -6,11 +6,11 @@ __all__ = ["GenericComponent"]
 
 
 class GenericComponent(ProgramHarness):
-    @classmethod
+    @classproperty
     def input(cls):
         return ProtoModel
 
-    @classmethod
+    @classproperty
     def output(cls):
         return ProtoModel
 

--- a/mmic/components/blueprints/generic_component.py
+++ b/mmic/components/blueprints/generic_component.py
@@ -1,5 +1,6 @@
 from ..base.base_component import ProgramHarness
-from cmselemental import models
+from cmselemental.models import ProtoModel
+from cmselemental.util.decorators import classproperty
 
 __all__ = ["GenericComponent"]
 
@@ -7,11 +8,11 @@ __all__ = ["GenericComponent"]
 class GenericComponent(ProgramHarness):
     @classmethod
     def input(cls):
-        return models.ProtoModel
+        return ProtoModel
 
     @classmethod
     def output(cls):
-        return models.ProtoModel
+        return ProtoModel
 
     @staticmethod
     def found(raise_error: bool = False) -> bool:
@@ -25,15 +26,5 @@ class GenericComponent(ProgramHarness):
         -------
         bool
             Returns True if the program was found, False otherwise.
-        """
-        raise NotImplementedError
-
-    @classmethod
-    def get_version(cls) -> str:
-        """Finds program, extracts version, returns normalized version string.
-        Returns
-        -------
-        str
-            Return a valid, safe python version string.
         """
         raise NotImplementedError

--- a/mmic/components/blueprints/strategy_component.py
+++ b/mmic/components/blueprints/strategy_component.py
@@ -66,17 +66,6 @@ class StrategyComponent(ProgramHarness):
             )
         return [spec for spec in cls.tactic_comps if importlib.util.find_spec(spec)]
 
-    @classmethod
-    @abc.abstractmethod
-    def get_version(cls) -> str:
-        """Finds program, extracts version, returns normalized version string.
-        Returns
-        -------
-        str
-            Return a valid, safe python version string.
-        """
-        raise NotImplementedError
-
     @classproperty
     @abc.abstractmethod
     def tactic_comps(cls) -> Set[str]:

--- a/mmic/components/blueprints/strategy_component.py
+++ b/mmic/components/blueprints/strategy_component.py
@@ -2,7 +2,6 @@ from ..base.base_component import ProgramHarness
 from typing import Dict, List, Set, Optional, Any, Tuple, Set
 from cmselemental.util.decorators import classproperty
 import importlib
-import abc
 
 __all__ = ["StrategyComponent"]
 
@@ -41,6 +40,7 @@ class StrategyComponent(ProgramHarness):
     def found(raise_error: bool = False) -> bool:
         """
         Checks if the program can be found.
+
         Parameters
         ----------
         raise_error : bool, optional
@@ -49,16 +49,19 @@ class StrategyComponent(ProgramHarness):
         -------
         bool
             Returns True if the program was found, False otherwise.
+
         """
         raise NotImplementedError
 
     @classproperty
     def installed_comps(cls) -> List[str]:
         """Returns module spec if it exists.
+
         Returns
         -------
-        List[str]
+        list[str]
             Component names that are installed.
+
         """
         if cls.tactic_comps is None:
             raise NotImplementedError(
@@ -67,11 +70,13 @@ class StrategyComponent(ProgramHarness):
         return [spec for spec in cls.tactic_comps if importlib.util.find_spec(spec)]
 
     @classproperty
-    @abc.abstractmethod
     def tactic_comps(cls) -> Set[str]:
-        """Returns the supported tactic components e.g. set(['mmic_mda',...]).
+        """Returns the tactic components this strategy component supports.
+
         Returns
         -------
-        Set[str]
+        set[str]
+            A set of compliant tactic component names.
+
         """
         raise NotImplementedError

--- a/mmic/components/blueprints/strategy_component.py
+++ b/mmic/components/blueprints/strategy_component.py
@@ -1,4 +1,5 @@
 from ..base.base_component import ProgramHarness
+import abc
 from typing import Dict, List, Set, Optional, Any, Tuple, Set
 from cmselemental.util.decorators import classproperty
 import importlib
@@ -69,6 +70,7 @@ class StrategyComponent(ProgramHarness):
             )
         return [spec for spec in cls.tactic_comps if importlib.util.find_spec(spec)]
 
+    @abc.abstractproperty
     @classproperty
     def tactic_comps(cls) -> Set[str]:
         """Returns the tactic components this strategy component supports.
@@ -79,4 +81,4 @@ class StrategyComponent(ProgramHarness):
             A set of compliant tactic component names.
 
         """
-        raise NotImplementedError
+        ...

--- a/mmic/components/blueprints/tactic_component.py
+++ b/mmic/components/blueprints/tactic_component.py
@@ -1,7 +1,6 @@
 from ..base.base_component import ProgramHarness
 from cmselemental.util.decorators import classproperty
 from typing import Set
-import abc
 
 __all__ = ["TacticComponent"]
 
@@ -19,15 +18,16 @@ class TacticComponent(ProgramHarness):
         -------
         bool
             Returns True if the program was found, False otherwise.
+
         """
         raise NotImplementedError
 
     @classproperty
-    @abc.abstractmethod
     def strategy_comps(cls) -> Set[str]:
-        """Returns the strategy component(s) this (tactic) component belongs to.
+        """Returns the strategy component(s) this (tactic) component is compliant with.
         Returns
         -------
-        Set[str]
+        set[str]
+            A set of strategy component names.
         """
         raise NotImplementedError

--- a/mmic/components/blueprints/tactic_component.py
+++ b/mmic/components/blueprints/tactic_component.py
@@ -7,25 +7,6 @@ __all__ = ["TacticComponent"]
 
 
 class TacticComponent(ProgramHarness):
-    @classmethod
-    @abc.abstractmethod
-    def get_version(cls) -> str:
-        """Returns distutils-style version string.
-
-        Examples
-        --------
-        The string ">1.0, !=1.5.1, <2.0" implies any version after 1.0 and before 2.0
-        is compatible, except 1.5.1
-
-        Returns
-        -------
-        str
-            Return a dist-utils valid version string.
-
-        """
-
-        raise NotImplementedError
-
     @staticmethod
     def found(raise_error: bool = False) -> bool:
         """

--- a/mmic/components/blueprints/tactic_component.py
+++ b/mmic/components/blueprints/tactic_component.py
@@ -1,4 +1,5 @@
 from ..base.base_component import ProgramHarness
+import abc
 from cmselemental.util.decorators import classproperty
 from typing import Set
 
@@ -22,6 +23,7 @@ class TacticComponent(ProgramHarness):
         """
         raise NotImplementedError
 
+    @abc.abstractproperty
     @classproperty
     def strategy_comps(cls) -> Set[str]:
         """Returns the strategy component(s) this (tactic) component is compliant with.
@@ -30,4 +32,4 @@ class TacticComponent(ProgramHarness):
         set[str]
             A set of strategy component names.
         """
-        raise NotImplementedError
+        ...

--- a/mmic/tests/test_base_components.py
+++ b/mmic/tests/test_base_components.py
@@ -1,0 +1,37 @@
+"""
+Unit and regression test for the mmic package.
+"""
+
+# Import package, test suite, and other packages as needed
+import mmic
+import sys
+
+
+def test_mmic_imported():
+    """Sample test, will always pass so long as import statement worked"""
+    assert "mmic" in sys.modules
+
+
+def test_mmic_program():
+
+    Foo = type(
+        "Foo",
+        (mmic.components.base.base_component.ProgramHarness,),
+        {
+            "version": lambda: ...,
+            "input": lambda: ...,
+            "output": lambda: ...,
+            "found": lambda: ...,
+            "execute": lambda: ...,
+        },
+    )
+
+    f = Foo(
+        name="foo",
+        scratch=False,
+        thread_safe=False,
+        thread_parallel=False,
+        node_parallel=False,
+        managed_memory=False,
+        extras=None,
+    )

--- a/mmic/tests/test_blueprint_components.py
+++ b/mmic/tests/test_blueprint_components.py
@@ -4,19 +4,15 @@ Unit and regression test for the mmic package.
 
 # Import package, test suite, and other packages as needed
 import mmic
-import pytest
 import sys
-
-
-def test_mmic_imported():
-    """Sample test, will always pass so long as import statement worked"""
-    assert "mmic" in sys.modules
 
 
 def test_mmic_generic():
 
     Foo = type(
-        "Foo", (mmic.components.blueprints.GenericComponent,), {"execute": lambda: ...}
+        "Foo",
+        (mmic.components.blueprints.GenericComponent,),
+        {"version": lambda: ..., "execute": lambda: ...},
     )
 
     f = Foo(
@@ -35,10 +31,10 @@ def test_mmic_strategy():
         "Foo",
         (mmic.components.blueprints.StrategyComponent,),
         {
-            "version": lambda: "",
-            "tactic_comps": lambda: set(),
-            "input": lambda: {},
-            "output": lambda: {},
+            "version": lambda: ...,
+            "tactic_comps": lambda: ...,
+            "input": lambda: ...,
+            "output": lambda: ...,
         },
     )
 
@@ -58,10 +54,10 @@ def test_mmic_tactic():
         "Foo",
         (mmic.components.blueprints.TacticComponent,),
         {
-            "version": lambda: "",
-            "strategy_comps": lambda: set(),
-            "input": lambda: {},
-            "output": lambda: {},
+            "version": lambda: ...,
+            "strategy_comps": lambda: ...,
+            "input": lambda: ...,
+            "output": lambda: ...,
             "execute": lambda: ...,
         },
     )

--- a/mmic/tests/test_mmcomponents.py
+++ b/mmic/tests/test_mmcomponents.py
@@ -35,7 +35,7 @@ def test_mmic_strategy():
         "Foo",
         (mmic.components.blueprints.StrategyComponent,),
         {
-            "version": "",
+            "version": lambda: "",
             "tactic_comps": lambda: set(),
             "input": lambda: {},
             "output": lambda: {},
@@ -58,7 +58,7 @@ def test_mmic_tactic():
         "Foo",
         (mmic.components.blueprints.TacticComponent,),
         {
-            "version": "",
+            "version": lambda: "",
             "strategy_comps": lambda: set(),
             "input": lambda: {},
             "output": lambda: {},

--- a/mmic/tests/test_mmcomponents.py
+++ b/mmic/tests/test_mmcomponents.py
@@ -14,9 +14,10 @@ def test_mmic_imported():
 
 
 def test_mmic_generic():
-    class Foo(mmic.components.blueprints.generic_component.GenericComponent):
-        def execute(self):
-            pass
+
+    Foo = type(
+        "Foo", (mmic.components.blueprints.GenericComponent,), {"execute": lambda: ...}
+    )
 
     f = Foo(
         name="foo",
@@ -30,22 +31,16 @@ def test_mmic_generic():
 
 
 def test_mmic_strategy():
-    class Foo(mmic.components.blueprints.strategy_component.StrategyComponent):
-        @classmethod
-        def input(cls):
-            return {}
-
-        @classmethod
-        def output(cls):
-            return {}
-
-        @classmethod
-        def get_version(cls):
-            return ""
-
-        @classmethod
-        def tactic_comps(cls):
-            return set()
+    Foo = type(
+        "Foo",
+        (mmic.components.blueprints.StrategyComponent,),
+        {
+            "version": "",
+            "tactic_comps": lambda: set(),
+            "input": lambda: {},
+            "output": lambda: {},
+        },
+    )
 
     f = Foo(
         name="foo",
@@ -59,25 +54,17 @@ def test_mmic_strategy():
 
 
 def test_mmic_tactic():
-    class Foo(mmic.components.blueprints.tactic_component.TacticComponent):
-        @classmethod
-        def input(cls):
-            return {}
-
-        @classmethod
-        def output(cls):
-            return {}
-
-        @classmethod
-        def get_version(cls):
-            return ""
-
-        @classmethod
-        def strategy_comps(cls):
-            return ""
-
-        def execute(self):
-            pass
+    Foo = type(
+        "Foo",
+        (mmic.components.blueprints.TacticComponent,),
+        {
+            "version": "",
+            "strategy_comps": lambda: set(),
+            "input": lambda: {},
+            "output": lambda: {},
+            "execute": lambda: ...,
+        },
+    )
 
     f = Foo(
         name="foo",

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     include_package_data=True,
     # Allows `setup.py test` to work correctly with pytest
     setup_requires=[] + pytest_runner,
-    install_requires=['pydantic','cmselemental'],
+    install_requires=["pydantic", "cmselemental"],
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
     ],


### PR DESCRIPTION
This patch simplifies certain methods/properties in ProgramHarness. Utilizes [classproperty](https://github.com/MolSSI/cmselemental/blob/v0.2.0/cmselemental/util/decorators.py#L5) from cmselemental for simpler/cleaner code. 

List of changes:
- Replaces classmethod `get_version` with classproperty `version`  in all components.
- Replaces `get_version` classmethod  with `version` classproperty.
- Changes `input/output` abstract classmethod to abstract classproperty.
- Simplifies testing code and adds test routine for `ProgramHarness`.